### PR TITLE
Complete REPL rework

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,6 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-slf4j" % akkaVersion,
   "com.typesafe.akka" %% "akka-http" % "10.2.0",
   "com.typesafe.akka" %% "akka-stream" % akkaVersion,
-  "com.lightbend.akka" %% "akka-stream-alpakka-unix-domain-socket" % "2.0.2",
   "ch.qos.logback" % "logback-classic" % "1.2.3",
   "org.scalatest" %% "scalatest" % "3.2.2" % Test
 )
@@ -77,6 +76,8 @@ libraryDependencies ++= Seq(
 libraryDependencies += "org.json4s" % "json4s-jackson_2.13" % "3.6.7"
 
 libraryDependencies += "de.mkammerer" % "argon2-jvm" % "2.9.1"
+
+libraryDependencies += "org.scala-sbt.ipcsocket" % "ipcsocket" % "1.3.0"
 //sbt-native-packaging Plugins for compiling to deb
 enablePlugins(DebianPlugin)
 enablePlugins(JavaServerAppPackaging)

--- a/src/main/scala/PrivateHome/UI/repl.scala
+++ b/src/main/scala/PrivateHome/UI/repl.scala
@@ -7,71 +7,55 @@ import akka.stream.OverflowStrategy
 import akka.stream.alpakka.unixdomainsocket.scaladsl.UnixDomainSocket
 import akka.stream.scaladsl.{SourceQueueWithComplete, _}
 import akka.util.ByteString
+import org.scalasbt.ipcsocket.UnixDomainServerSocket
+import org.slf4j.LoggerFactory
 
+import java.io.{BufferedReader, File, IOException, InputStreamReader, PrintWriter}
 import java.math.BigInteger
 import java.nio.file.{Path, Paths}
 import java.security.SecureRandom
 import scala.concurrent.Future
 
 
-class repl {
-  val path: Path = Paths.get("/tmp/privatehome.sock") //here we need to use Java wich isn't that beautiful but bind and handle only accepts java.nio.file.Path
-  val binding: Future[UnixDomainSocket.ServerBinding] = UnixDomainSocket().bindAndHandle(cliHandler.listen(), path)
-}
+object repl {
+  private val logger = LoggerFactory.getLogger(this.getClass)
+  val socketPath = "/tmp/privatehome2.sock"
+  val serverSocket = new UnixDomainServerSocket(socketPath)
 
-object cliHandler {
-  def listen(): Flow[ByteString, ByteString, NotUsed] = {
-    var connectionOut: ByteString => Unit = null
-    var args: Array[String] = null
-    val inboundHandle: Sink[String, Any] = Sink.foreach(msg => {
-      try {
-        val command: Array[String] = msg.stripSuffix(")").split('(')
-        args = if ((command.length == 2) && (command(1) != null)) command(1).split(',') else null
-        println(s"command = ${command(0)}")
-
-        val uiCommand: Command = command(0) match {
-          case "commandAddUserBase64" =>
-            commandAddUserBase64(args(0), args(1))
-          case "commandRecreateDatabase" => commandRecreateDatabase()
-          case "commandSafeCreateDatabase" => commandSafeCreateDatabase()
-          case "getRandomId" =>
-            val random = new SecureRandom()
-            var id: String = null
-            var run = true
-            while (run) {
-              id = new BigInteger(5 * 5, random).toString(32) //  This generates a random String with length 5
-              try {
-                data.idTest(id, create = true)
-                println(id)
-                connectionOut.apply(ByteString(id + "\n"))
-                run = false
-              }
-              catch {
-                case _: IllegalArgumentException =>
-              }
+  class readThread extends Thread {
+    override def run(): Unit = {
+      while (true) {
+        val clientSocket = serverSocket.accept()
+        try {
+          val out = new PrintWriter(clientSocket.getOutputStream, true)
+          val in =
+            new BufferedReader(new InputStreamReader(clientSocket.getInputStream))
+          var line: String = null
+          do {
+            line = in.readLine()
+            if (line != null) {
+              out.println(stringCommandHandler.interpretMessage(line))
             }
-            new Command
-          case "commandOn" => commandOn(args(0), args(1))
-          case "commandOff" => commandOff(args(0))
-          case "commandAddDevice" => commandAddDevice(args(0), args(1), args(2), args(3), args(4), args(5), args(6).toBoolean)
-
-          case _ => println("Unknown Command")
-            new Command
+          } while (line != null && !line.trim().equals("bye"))
+        } catch {
+          case _: IOException =>
         }
-        uiControl.receiveCommand(uiCommand)
-
-      } catch {
-        case e: Throwable => println(e)
-          e.printStackTrace()
       }
-    })
-    val inbound: Sink[ByteString, NotUsed] = Flow[ByteString].via(Framing.delimiter(ByteString("\n"), 256, allowTruncation = true)).map(_.utf8String).to(inboundHandle)
 
-    val outbound: Source[ByteString, SourceQueueWithComplete[ByteString]] = Source.queue[ByteString](16, OverflowStrategy.fail)
-    Flow.fromSinkAndSourceMat(inbound, outbound)((_, outboundMat) => {
-      connectionOut = outboundMat.offer
-      NotUsed
-    })
+    }
+  }
 
+  val thread = new readThread
+
+  thread.start()
+  logger.info("Started repl handler thread")
+
+  def shutdown(): Unit ={
+    logger.info("Shutting down repl")
+    val socketfile = new File(socketPath)
+    serverSocket.close()
+    socketfile.delete()
+    logger.info("REPL shut down")
   }
 }
+

--- a/src/main/scala/PrivateHome/UI/stringCommandHandler.scala
+++ b/src/main/scala/PrivateHome/UI/stringCommandHandler.scala
@@ -1,0 +1,56 @@
+package PrivateHome.UI
+
+import PrivateHome.data
+import org.slf4j.LoggerFactory
+
+import java.math.BigInteger
+import java.security.SecureRandom
+
+object stringCommandHandler {
+  private val logger = LoggerFactory.getLogger(this.getClass)
+  def interpretMessage(msg: String): Any = {
+    try {
+      val command: Array[String] = msg.stripSuffix(")").split('(')
+      val args = if ((command.length == 2) && (command(1) != null)) command(1).split(',') else null
+      logger.debug("command = {}",command(0))
+
+      val uiCommand = command(0) match {
+        case "commandAddUserBase64" =>
+          commandAddUserBase64(args(0), args(1))
+        case "commandRecreateDatabase" => commandRecreateDatabase()
+        case "commandSafeCreateDatabase" => commandSafeCreateDatabase()
+        case "getRandomId" =>
+          var id: String = null
+          val random = new SecureRandom()
+          var run = true
+          while (run) {
+
+            id = new BigInteger(5 * 5, random).toString(32) //  This generates a random String with length 5
+            try {
+              data.idTest(id, create = true)
+              logger.debug("Recomended id: \"{}\"",id)
+              run = false
+            }
+            catch {
+              case _: IllegalArgumentException =>
+            }
+          }
+          id
+        case "commandOn" => commandOn(args(0), args(1))
+        case "commandOff" => commandOff(args(0))
+        case "commandAddDevice" => commandAddDevice(args(0), args(1), args(2), args(3), args(4), args(5), args(6).toBoolean)
+
+        case _ => logger.warn("Unknown Command")
+          new Command
+      }
+      uiCommand match {
+        case c:Command => uiControl.receiveCommand(c)
+        case s:String => s
+      }
+
+    } catch {
+      case e: Throwable => logger.error("Unknown Error while interpreting Console command",e)
+        e + e.getStackTrace.mkString("\n")
+    }
+  }
+}

--- a/src/main/scala/PrivateHome/privatehome.scala
+++ b/src/main/scala/PrivateHome/privatehome.scala
@@ -21,7 +21,7 @@ object privatehome {
 
     gui
     data
-    val repl = new repl()
+    repl
     logger.debug("Registering Shutdown Handler")
     val intHandler = new SignalHandler {
       override def handle(signal: Signal): Unit = {
@@ -34,7 +34,7 @@ object privatehome {
 
   def shutdown(exitCode: Int = 0): Unit = {
     logger.info("Shutting down Server")
-    repl.shutdown
+    repl.shutdown()
     sys.exit(exitCode)
   }
 


### PR DESCRIPTION
Changed repl to be an object that handles the connection to the console without alpakka.

Because the repl command are not really dependent on the socket and could theoretically could also come from another trusted source.
The parsing and execution of stringCommands is now handled by stringCommandHandler and the interpretMessage methode.

We switched form akka-stream-alpakka-unix-domain-socket to org.scala-sbt.ipcsocket because it is more lightweight and I had a big problem with implementing the two way communication.
So now that we have two way communication we can get a random free ID from the server that way its more easy to add a switch.
Since you do not need to know which id is free or are predictable.