### PR TITLE
Add Log4Shell warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # PrivateHome
 [![Scala CI](https://github.com/PrivateHomeIoT/PrivateHome/actions/workflows/scala.yml/badge.svg)](https://github.com/PrivateHomeIoT/PrivateHome/actions/workflows/scala.yml) [![codecov](https://codecov.io/gh/PrivateHomeIoT/PrivateHome/branch/master/graph/badge.svg)](https://codecov.io/gh/PrivateHomeIoT/PrivateHome)
 
+# **WARNING: This program uses Log4J and might be affected by Log4Shell**
+
 ## Description
 
 This is a SmartHome project focused on design, security and expandability. It is programmed in Scala.


### PR DESCRIPTION
Updated the readme to contain a warning about Log4Shell because we use Log4J but haven't check yet if we are affected by this.
But the chance that we are is pretty high since we don't deactivate Variable replacement.